### PR TITLE
Fix php8.1 deprecations, run tests on php8.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.4, 8.0]
+        php: [7.4, 8.0, 8.1]
 
     name: PHP ${{ matrix.php }}
 

--- a/src/UnicodeString.php
+++ b/src/UnicodeString.php
@@ -862,6 +862,7 @@ class UnicodeString implements Countable, ArrayAccess, JsonSerializable
     /**
      * @inheritDoc
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         // Allow negative index
@@ -897,6 +898,7 @@ class UnicodeString implements Countable, ArrayAccess, JsonSerializable
     /**
      * @inheritDoc
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         throw new RuntimeException("Invalid operation");


### PR DESCRIPTION
Another way to fix the deprecations in to add return types.

Let me know if you prefer this way