### PR TITLE
PHP 8.4: Fix implictly nullable parameters

### DIFF
--- a/src/Exception/InvalidCodePointException.php
+++ b/src/Exception/InvalidCodePointException.php
@@ -30,7 +30,7 @@ class InvalidCodePointException extends UnicodeException
      * @param $codePoint
      * @param Throwable|null $previous
      */
-    public function __construct($codePoint, Throwable $previous = null)
+    public function __construct($codePoint, ?Throwable $previous = null)
     {
         parent::__construct("Invalid code point", 0, $previous);
         $this->codePoint = $codePoint;

--- a/src/Exception/InvalidStringException.php
+++ b/src/Exception/InvalidStringException.php
@@ -36,7 +36,7 @@ class InvalidStringException extends UnicodeException
      * @param int $offset
      * @param Throwable|null $previous
      */
-    public function __construct(string $string, int $offset = -1, Throwable $previous = null)
+    public function __construct(string $string, int $offset = -1, ?Throwable $previous = null)
     {
         parent::__construct("Invalid UTF-8 string at offset {$offset}", 0, $previous);
         $this->string = $string;


### PR DESCRIPTION
https://wiki.php.net/rfc/deprecate-implicitly-nullable-types